### PR TITLE
Add simple microbenchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,12 @@ keywords = ["storage","indexing","query","database"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
+
+[dev-dependencies]
+docopt = "0.6"
+time = "0.1"
+
+[[bench]]
+name = "bench"
+path = "benches/bench.rs"
+harness = false

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,85 @@
+#![feature(test)]
+
+// Basic microbenchmark.
+//
+// Usage:
+//
+//     $ cargo bench --bench bench -- --use-index [...]
+//
+
+extern crate docopt;
+extern crate shortcut;
+extern crate test;
+extern crate time;
+
+use docopt::Docopt;
+use shortcut::cmp;
+use shortcut::idx;
+use shortcut::Store;
+use time::PreciseTime;
+
+
+const USAGE: &'static str = "
+Benchmark shortcut.
+
+Usage:
+  bench [--rounds=N --use-index --bench]
+
+Options:
+  --rounds=N               Number of rounds to run. [default: 1000000]
+  --use-index              Install a hash index for fast lookups.
+  --bench                  Appease `cargo bench`. No effect.
+";
+
+
+fn main() {
+    let args = Docopt::new(USAGE)
+        .and_then(|dopt| dopt.parse())
+        .unwrap_or_else(|e| e.exit());
+
+    let mut store = Store::new(2);
+
+    let rounds: u32 = args.get_str("--rounds").parse().unwrap();
+
+    if args.get_bool("--use-index") {
+        store.index(0, idx::HashIndex::new());
+    }
+
+    let t0 = PreciseTime::now();
+
+    // Put.
+    for i in 0..rounds {
+        let istr = format!("{}", i);
+        store.insert(vec![istr.clone(), istr])
+    }
+
+    let t1 = PreciseTime::now();
+
+    // Get.
+    for i in 0..rounds {
+        let cmp = [cmp::Condition {
+            column: 0,
+            cmp: cmp::Comparison::Equal(cmp::Value::Const(format!("{}", i))),
+        }];
+
+        let rows = store.find(&cmp);
+
+        for row in rows {
+            test::black_box(row);
+        }
+    }
+
+    let t2 = PreciseTime::now();
+
+    println!("put time: {:.2}ms ({:.2} puts/sec)",
+             t0.to(t1).num_milliseconds(),
+             ops_per_sec(rounds, t0, t1));
+
+    println!("get time: {:.2}ms ({:.2} gets/sec)",
+             t1.to(t2).num_milliseconds(),
+             ops_per_sec(rounds, t1, t2));
+}
+
+fn ops_per_sec(rounds: u32, start: PreciseTime, end: PreciseTime) -> f64 {
+    1000.0 * (rounds as f64) / (start.to(end).num_milliseconds() as f64)
+}


### PR DESCRIPTION
No promises this isn't doing something stupid ;)

On my machine:

```
$ cargo bench --bench bench -- --use-index --rounds=10000000 
     Running target/release/bench-f52c9464baf3735e
put time: 9136ms (1094570.93 puts/sec)
get time: 6109ms (1636929.12 gets/sec)

$ cargo bench --bench bench -- --rounds=10000
     Running target/release/bench-f52c9464baf3735e
put time: 2ms (5000000.00 puts/sec)
get time: 7267ms (1376.08 gets/sec)
```
